### PR TITLE
Fix Lighthouse CI autorun configuration

### DIFF
--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -4,7 +4,7 @@
       "url": ["http://localhost:8080"],
       "numberOfRuns": 1,
       "startServerCommand": "npm run build:assets && npm run serve:lighthouse",
-      "startServerReadyPattern": "Accepting connections",
+      "startServerReadyPattern": "http://localhost:8080",
       "settings": {
         "onlyCategories": ["performance", "accessibility", "best-practices", "seo"],
         "skipAudits": ["screenshot-thumbnails", "final-screenshot", "full-page-screenshot"],

--- a/scripts/run-lighthouse.js
+++ b/scripts/run-lighthouse.js
@@ -9,10 +9,27 @@ const { executablePath } = require('puppeteer');
       throw new Error('No se pudo resolver la ruta del ejecutable de Chromium proporcionado por Puppeteer.');
     }
 
+    const defaultFlags = '--no-sandbox --disable-dev-shm-usage';
+    const normalizeFlags = value =>
+      value
+        .split(/\s+/)
+        .filter(Boolean)
+        .filter((flag, index, arr) => arr.indexOf(flag) === index)
+        .join(' ');
+
+    const chromiumFlags = [process.env.LHCI_CHROMIUM_FLAGS, defaultFlags]
+      .filter(Boolean)
+      .join(' ');
+
+    const chromeFlags = [process.env.LHCI_CHROME_FLAGS, defaultFlags]
+      .filter(Boolean)
+      .join(' ');
+
     const env = {
       ...process.env,
       CHROME_PATH: chromePath,
-      LHCI_CHROME_FLAGS: `${process.env.LHCI_CHROME_FLAGS || ''} --no-sandbox --disable-dev-shm-usage`.trim(),
+      LHCI_CHROMIUM_FLAGS: normalizeFlags(chromiumFlags),
+      LHCI_CHROME_FLAGS: normalizeFlags(chromeFlags),
     };
 
     const lhciCli = require.resolve('@lhci/cli/src/cli.js');


### PR DESCRIPTION
## Summary
- update the local Lighthouse CI configuration to wait for the actual "serve" startup message
- harden the run-lighthouse helper so both Chromium flag env vars include the required sandbox overrides

## Testing
- npm run lighthouse *(fails in container: Chromium requires libatk-1.0.so.0)*
- npm run validate *(fails: repository already contains unformatted JS files)*

------
https://chatgpt.com/codex/tasks/task_e_69000a65659c8331ad2d37288850fadc